### PR TITLE
improve: Re-work file date coloring to be darker

### DIFF
--- a/dark_colors.yaml
+++ b/dark_colors.yaml
@@ -21,9 +21,9 @@ exec:      '#8be9fd'         # Cyan
 no_access: '#ff5555'         # Red
 
 # Age
-hour_old:    '#6272a4'       # Comment
-day_old:     '#44475a'       # Current Line
-no_modifier: '#f8f8f2'       # Foreground
+hour_old:    '#95a5d7'       # Comment - 20% lighter
+day_old:     '#6272a4'       # Comment
+no_modifier: '#44475a'       # Current Line
 
 # File Size
 file_large:  '#ff5555'       # Red


### PR DESCRIPTION
# Info -- Dracula hates the light!!
Changes date coloring to remove foreground (`#f8f8f2`) coloring. This resulted in a lot of foreground coloring in directories with many >1 day old files when viewed with long format; every single recognized file will also be colored with `#f8f8f2` as well.


* Shift current-line and comment coloring to one "date type" older
* Make recently created/modified files use comment color code, but 20% lighter
   * Wanted to still be dark, but the "dark" colors of the dracula theme are all already in use.
   * Any other dracula default color left is neon or foreground, which imo is too bright. Comment+20% lighter still seems close enough to comment, but able to be differentiated between standard comment.

### Before
![Screen Shot 2020-11-30 at 2 50 04 PM](https://user-images.githubusercontent.com/9803299/100656848-5c439a80-331b-11eb-9330-5b4014ffdb3c.png)

### After
(Bottom three going in order from `hour_old`, to `day_old`, to `no_modifier`.

![Screen Shot 2020-11-30 at 2 39 42 PM](https://user-images.githubusercontent.com/9803299/100656591-efc89b80-331a-11eb-82a2-1c3b2ffc9d9f.png)